### PR TITLE
Make acts_as_user a noop when the table is missing

### DIFF
--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -1,7 +1,7 @@
 module Canard
 
   module UserModel
-    
+
     # Canard applies roles to a model using the acts_as_user class method. The following User model
     # will be given the :manager and :admin roles
     #
@@ -40,27 +40,29 @@ module Canard
     #
     # returns all the users who don't have the manager role.
     def acts_as_user(*args)
-      include RoleModel
+      if table_exists?
+        include RoleModel
 
-      options = args.extract_options!.symbolize_keys
+        options = args.extract_options!.symbolize_keys
 
-      roles options[:roles] if options.has_key?(:roles) && column_names.include?(roles_attribute_name.to_s)
-              
-      valid_roles.each do |role|
-        define_scopes_for_role role
-      end
-    
-      define_scope_method(:with_any_role) do |*roles|
-        where("#{role_mask_column} & :role_mask > 0", { :role_mask => mask_for(*roles) })
-      end
-    
-      define_scope_method(:with_all_roles) do |*roles|
-        where("#{role_mask_column} & :role_mask = :role_mask", { :role_mask => mask_for(*roles) })
+        roles options[:roles] if options.has_key?(:roles) && column_names.include?(roles_attribute_name.to_s)
+
+        valid_roles.each do |role|
+          define_scopes_for_role role
+        end
+
+        define_scope_method(:with_any_role) do |*roles|
+          where("#{role_mask_column} & :role_mask > 0", { :role_mask => mask_for(*roles) })
+        end
+
+        define_scope_method(:with_all_roles) do |*roles|
+          where("#{role_mask_column} & :role_mask = :role_mask", { :role_mask => mask_for(*roles) })
+        end
       end
     end
-    
+
     private
-    
+
     def define_scopes_for_role(role)
       include_scope   = role.to_s.pluralize
       exclude_scope   = "non_#{include_scope}"
@@ -73,13 +75,13 @@ module Canard
         where("#{role_mask_column} & :role_mask = 0 or #{role_mask_column} is null", { :role_mask => mask_for(role) })
       end
     end
-    
+
     def define_scope_method(method, &block)
       (class << self; self end).class_eval do
         define_method(method, block)
       end
     end
-    
+
     def role_mask_column
       %{"#{table_name}"."#{roles_attribute_name}"}
     end


### PR DESCRIPTION
I hit a problem when running db:migrate or db:setup when the user table does not existing in the database as "acts_as_user" unconditionally tried to access column definitions.
