### PR TITLE
Added missing information

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@ definitions gain their own folder and a little structure. The easiest way to get
 Canard generator. Canard progressively enhances the abilities of the model by applying role abilities on
 top of the models base abilities.
 
-A User model with :admin and :manger roles would be defined:
+A User model with :admin and :manager roles would be defined:
 
     class User < ActiveRecord::Base
 
@@ -128,6 +128,11 @@ User.with_all_roles(roles)::  return only the users with all the specified roles
 Add the canard gem to your Gemfile. In Gemfile:
 
     gem "canard"
+
+Add the `roles_mask` field to your user table:
+
+    rails g migration add_roles_mask_to_users roles_mask:integer
+    rake db:migrate
 
 That's it!
 


### PR DESCRIPTION
I was really confused as to why the role scopes weren't working or any helper method really: it's necessary to manually add the roles_mask field to the user table.

My definition:

``` ruby
class AdminUser < ActiveRecord::Base
  devise :database_authenticatable, 
         :recoverable, :rememberable, :trackable, :validatable

  attr_accessible :email, :password, :password_confirmation, :remember_me, :roles

  acts_as_user roles: [:contributor, :blogger, :producer, :admin]
end
```

Example errors:

```
2.0.0-p0 :005 > AdminUser.admins
NoMethodError: undefined method `admins' for #<Class:0x007f8f96372760>
```

```
2.0.0-p0 :002 > AdminUser.valid_roles
 => []
```

```
2.0.0-p0 :002 > AdminUser.first.roles = ['admin']
  AdminUser Load (1.8ms)  SELECT "admin_users".* FROM "admin_users" LIMIT 1
NoMethodError: undefined method `roles_mask=' for #<AdminUser:0x007fac0bfee480>
```

```
2.0.0-p0 :001 > AdminUser.with_any_role
  AdminUser Load (1.4ms)  SELECT "admin_users".* FROM "admin_users" WHERE ("admin_users"."roles_mask" & 0 > 0)
ActiveRecord::StatementInvalid: PG::Error: ERROR:  column admin_users.roles_mask does not exist
```

Added missing info to the README.
