### PR TITLE
Add support for mongoid 4

### DIFF
--- a/lib/canard/adapters/mongoid.rb
+++ b/lib/canard/adapters/mongoid.rb
@@ -30,8 +30,8 @@ module Canard
         include_scope   = role.to_s.pluralize
         exclude_scope   = "non_#{include_scope}"
         
-        scope include_scope, where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0")
-        scope exclude_scope, any_of({roles_attribute_name  => { "$exists" => false }}, {roles_attribute_name => nil}, {"$where" => "(this.#{roles_attribute_name} & #{mask_for(role)}) === 0"})
+        scope include_scope, lambda { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }
+        scope exclude_scope, lambda { any_of({roles_attribute_name  => { "$exists" => false }}, {roles_attribute_name => nil}, {"$where" => "(this.#{roles_attribute_name} & #{mask_for(role)}) === 0"}) }
       end
 
     end


### PR DESCRIPTION
There is a problem with the user scopes in mongoid 4.0.0.alpha2. 

When trying to start rails or run tests with an app using 4.0.0.alpha2 and canard the following error is thrown.

```
Problem:
  Defining a scope of value #<Mongoid::Criteria:0x007fe4a48d3e30> on User is not allowed.
Summary:
  Scopes in Mongoid must be procs that wrap criteria objects.
Resolution:
  Change the scope to be a proc wrapped critera.

 Example:
   class Band
     include Mongoid::Document
     scope :inactive, ->{ where(active: false) }
   end
```

This should fix the issue. If you want to wait until 4.0 is out of beta to merge this, that's fine.
