### PR TITLE
Fix tests for ruby > 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - ree
   - 1.8.7
   - 1.9.3
+  - 2.0.0
+  - 2.1.0
   - jruby-18mode # JRuby in 1.8 mode
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-18mode

--- a/test/canard/user_model_test.rb
+++ b/test/canard/user_model_test.rb
@@ -12,7 +12,7 @@ describe Canard::UserModel do
 
       it 'adds role_model to the class' do
         PlainRubyUser.included_modules.must_include RoleModel
-        PlainRubyUser.must_respond_to :roles
+        PlainRubyUser.new.must_respond_to :roles
       end
     end
 


### PR DESCRIPTION
When working on https://github.com/james2m/canard/pull/15 with ruby 2.1 I noticed this failing test. It seems this failure started happening with ruby 2.0

This fixes the test, though I'm not super sure why the change is necessary. I looked around online to see if anyone else had this problem and didn't find anything.
