### PR TITLE
Make Ability's private methods protected

### DIFF
--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -53,7 +53,7 @@ class Ability
 
   end
 
-  private
+  protected
 
   def append_abilities(key)
     ability_definitions = Canard.ability_definitions


### PR DESCRIPTION
Make methods `protected` over `private` to ease enhancement and modification.
