### PR TITLE
Remove check for rails, noop here in gemspec

### DIFF
--- a/canard.gemspec
+++ b/canard.gemspec
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "canard/version"
-require 'rails'
 
 Gem::Specification.new do |s|
   s.name        = "canard"
@@ -30,10 +29,6 @@ Gem::Specification.new do |s|
   end
 
   s.requirements << 'cancan for Rails3 and earlier or the Rails4 compatible cancancan fork.'
-  if Rails.version > '3'
-    s.add_runtime_dependency "cancancan"
-  else
-    s.add_runtime_dependency "cancan"
-  end
+  s.add_runtime_dependency "cancancan"
   s.add_runtime_dependency "role_model"
 end


### PR DESCRIPTION
Instead cancancan is rails 3 and rails 2 compatible according to its readme. Should be good to just rely on it. Addresses #21 
