### PR TITLE
Adds functionality to 'inherit' abilities between roles

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -87,6 +87,31 @@ And it's associated test spec/abilities/users_spec.rb;
 
     end
 
+You can also re-use abilities defined for one role in another. This allows you to 'inherit' abilities without having to assign all of the roles to the user. To do this, pass a list of role names to the includes_abilities_of method
+
+    Canard::Abilities.for(:writer) do
+
+      can     [:create], Post
+      can     [:read], Post, user_id: user.id
+
+    end
+
+    Canard::Abilities.for(:reviewer) do
+
+      can     [:read, :update], Post
+
+    end
+
+    Canard::Abilities.for(:admin) do
+
+      includes_abilities_of :writer, :reviewer
+
+      can     [:delete], Post
+
+    end
+
+A user assigned the :admin role will have all of the abilities of the :writer and :reviewer, along with their own abilities without having to have those individual roles assigned to them.
+
 Now lets generate some abilities for the manager and admin.
 
     $ rails g canard:ability admin can:manage:[account,statement]

--- a/lib/ability.rb
+++ b/lib/ability.rb
@@ -66,4 +66,8 @@ class Ability
     class_name.downcase!.to_sym
   end
 
+  def includes_abilities_of(*other_roles)
+    other_roles.each { |other_role| append_abilities(other_role) }
+  end
+
 end

--- a/lib/canard/version.rb
+++ b/lib/canard/version.rb
@@ -1,3 +1,3 @@
 module Canard
-  VERSION = "0.4.2.pre"
+  VERSION = "0.4.3"
 end

--- a/test/canard/ability_test.rb
+++ b/test/canard/ability_test.rb
@@ -93,6 +93,29 @@ describe Ability do
 
     end
 
+    describe "a user with editor role" do
+      let(:user) { User.create(:roles => [:editor]) }
+      let(:member) { Member.create(:user => user) }
+      let(:other_user) { User.create }
+      let(:other_member) { Member.new(:user => other_user) }
+      subject { Ability.new(user) }
+
+      it "has all the abilities of the base class" do
+        subject.can?(:edit, member).must_equal true
+        subject.can?(:update, member).must_equal true
+
+        subject.cannot?(:edit, other_member).must_equal true
+        subject.cannot?(:update, other_member).must_equal true
+      end
+
+      it "has most of the abilities of authors, except it can't create Posts" do
+        subject.can?(:update, Post).must_equal true
+        subject.can?(:read, Post).must_equal true
+        subject.cannot?(:create, Post).must_equal true
+      end
+
+    end
+
     describe "with no user" do
 
       subject { Ability.new }

--- a/test/canard/adapters/active_record_test.rb
+++ b/test/canard/adapters/active_record_test.rb
@@ -7,9 +7,9 @@ describe Canard::Adapters::ActiveRecord do
     describe 'with a role_mask' do
 
       describe 'and :roles => [] specified' do
-        
+
         it 'sets the valid_roles for the class' do
-          User.valid_roles.must_equal [:viewer, :author, :admin]
+          User.valid_roles.must_equal [:viewer, :author, :admin, :editor]
         end
 
       end
@@ -35,23 +35,23 @@ describe Canard::Adapters::ActiveRecord do
     end
 
     describe "with no table" do
-        
+
       subject { Class.new(ActiveRecord::Base) }
 
       it "sets no roles" do
         subject.class_eval { acts_as_user :roles => [:admin] }
         subject.valid_roles.must_equal []
       end
-        
+
       it "does not raise any errors" do
         proc { subject.class_eval { acts_as_user :roles => [:admin] } }.must_be_silent
       end
-        
+
       it "returns nil" do
         subject.class_eval { acts_as_user :roles => [:admin] }.must_be_nil
       end
     end
-    
+
     describe 'with an alternative roles_mask specified' do
 
       before do

--- a/test/dummy/app/abilities/editors.rb
+++ b/test/dummy/app/abilities/editors.rb
@@ -1,0 +1,7 @@
+Canard::Abilities.for(:editor) do
+
+  includes_abilities_of :author
+
+  cannot :create, Post
+
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
-  
-  acts_as_user :roles => [:viewer, :author, :admin]
-  
+
+  acts_as_user :roles => [:viewer, :author, :admin, :editor]
+
   attr_accessible :roles
 end


### PR DESCRIPTION
Allows role-based ability files to refer to other roles' ability so ability definitions do not need to be repeated across roles