### PR TITLE
Added prefix optional parameter for acts_as_user method

### DIFF
--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -37,7 +37,7 @@ module Canard
       end
 
       def define_scopes_for_role(role, prefix=nil)
-        prefix = prefix? "#{prefix}_" : ''
+        prefix = prefix ? "#{prefix}_" : ''
         include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -38,7 +38,7 @@ module Canard
 
       def define_scopes_for_role(role, prefix=nil)
         prefix = prefix ? "#{prefix}_" : ''
-        include_scope   = "#{prefix}role.to_s.pluralize"
+        include_scope   = "#{prefix}#{role.to_s.pluralize}"
         exclude_scope   = "non_#{include_scope}"
 
         define_scope_method(include_scope) do

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -5,12 +5,11 @@ module Canard
       private
 
       def add_role_scopes(*args)
-        options = args.extract_options!
-        prefix = "#{options[:prefix]}_" || ''
+        options = args.extract_options!        
         # TODO change to check has_roles_attribute?
         if active_record_table?
           valid_roles.each do |role|
-            define_scopes_for_role role, prefix
+            define_scopes_for_role role, options[:prefix]
           end
 
           # TODO change hard coded :role_mask to roles_attribute_name
@@ -37,7 +36,8 @@ module Canard
         active_record_table? && column_names.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role, prefix)
+      def define_scopes_for_role(role, prefix=nil)
+        prefix = prefix? "#{prefix}_" : ''
         include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -4,11 +4,13 @@ module Canard
 
       private
 
-      def add_role_scopes
+      def add_role_scopes(*args)
+        options = args.extract_options!
+        prefix = "#{options[:prefix]}_" || ''
         # TODO change to check has_roles_attribute?
         if active_record_table?
           valid_roles.each do |role|
-            define_scopes_for_role role
+            define_scopes_for_role role, prefix
           end
 
           # TODO change hard coded :role_mask to roles_attribute_name
@@ -35,8 +37,8 @@ module Canard
         active_record_table? && column_names.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role)
-        include_scope   = role.to_s.pluralize
+      def define_scopes_for_role(role, prefix)
+        include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 
         define_scope_method(include_scope) do

--- a/lib/canard/adapters/mongoid.rb
+++ b/lib/canard/adapters/mongoid.rb
@@ -4,9 +4,10 @@ module Canard
 
       private
 
-      def add_role_scopes
+      def add_role_scopes(*args)
+        options = args.extract_options!   
         valid_roles.each do |role|
-          define_scopes_for_role role
+          define_scopes_for_role role, options[:prefix]
         end
 
         def with_any_role(*roles)
@@ -26,8 +27,9 @@ module Canard
        fields.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role)
-        include_scope   = role.to_s.pluralize
+      def define_scopes_for_role(role, prefix=nil)
+        prefix = prefix ? "#{prefix}_" : ''
+        include_scope   = "#{prefix}#{role.to_s.pluralize}"
         exclude_scope   = "non_#{include_scope}"
         
         scope include_scope, lambda { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      # add_role_scopes if respond_to?(:add_role_scopes, true)
+      add_role_scopes(options[:prefix]) if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      add_role_scopes if respond_to?(:add_role_scopes, true)
+      # add_role_scopes if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      add_role_scopes(options[:prefix]) if respond_to?(:add_role_scopes, true)
+      add_role_scopes(prefix: options[:prefix]) if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/version.rb
+++ b/lib/canard/version.rb
@@ -1,3 +1,3 @@
 module Canard
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
Faced the problem, when generated buy "add_role_scopes" methods conflicted with methods, generated by has_many relation (or any other relation or scope). I wanted to save most of canard`s methods and didn`t want to rename my relations. So I made the possibility to add the prefix for generated "positive" scopes. So, User.children will be User.#{prefix}_children, for example.
