### PR TITLE
Tweak generators for rails 4+

### DIFF
--- a/canard.gemspec
+++ b/canard.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors     = ["James McCarthy"]
   s.email       = ["james2mccarthy@gmail.com"]
   s.homepage    = "https://github.com/james2m/canard"
-  s.summary     = %q{Adds role based authorisation to Rails by combining RoleModel and CanCan.}
-  s.description = %q{Wraps CanCan and RoleModel up to make role based authorisation really easy in Rails 3.x.}
+  s.summary     = %q{Adds role based authorisation to Rails by combining RoleModel and CanCanCan.}
+  s.description = %q{Wraps CanCanCan and RoleModel up to make role based authorisation really easy in Rails 4+.}
 
   s.rubyforge_project = "canard"
 
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "mongoid", "~> 3.0"
   end
 
-  s.requirements << 'cancan for Rails3 and earlier or the Rails4 compatible cancancan fork.'
+  s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
   s.add_runtime_dependency "cancancan"
   s.add_runtime_dependency "role_model"
 end

--- a/lib/generators/canard/ability/templates/abilities.rb.erb
+++ b/lib/generators/canard/ability/templates/abilities.rb.erb
@@ -1,5 +1,4 @@
 Canard::Abilities.for(<%= ":#{name}" -%>) do
-
 <% if ability_definitions.empty? -%>
   # Define abilities for the user role here. For example:
   #
@@ -19,14 +18,13 @@ Canard::Abilities.for(<%= ":#{name}" -%>) do
   # The third argument is an optional hash of conditions to further filter the objects.
   # For example, here the user can only update published articles.
   #
-  #   can :update, Article, :published => true
+  #   can :update, Article, published: true
   #
-  # See the wiki for details: https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  # See the wiki for details: https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 <% else -%>
 <% definitions do |model, definition| -%>
-  <%= "can".ljust(8, ' ') + "#{definition.cans.map(&:to_sym)}, #{model.classify}" unless definition.cans.empty? %>
-  <%= "cannot".ljust(8, ' ') + "#{definition.cannots.map(&:to_sym)}, #{model.classify}" unless definition.cannots.empty? %>
+  <%= "can #{definition.cans.map(&:to_sym)}, #{model.classify}" unless definition.cans.empty? %>
+  <%= "cannot #{definition.cannots.map(&:to_sym)}, #{model.classify}" unless definition.cannots.empty? %>
 <% end -%>
 <% end -%>
-
 end

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -1,68 +1,42 @@
-require_relative '../spec_helper'
+require 'rails_helper'
+require 'cancan/matchers'
 
-require "cancan/matchers"
-
-describe Canard::Abilities, "for <%= plural_name %>" do
-
-  before do
+describe Canard::Abilities, 'for <%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-    @user = Factory.create(:<%= name %>_user)
+  let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-    @user = User.make!(:<%= name %>)
+  let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
-  @user = User.create(:roles => %w(<%= name -%>))
+  let(:<%= name %>) { User.create(roles: %w(<%= name -%>)) }
 <% end -%>
-  end
-  
-  subject { Ability.new(@user) }
-  
+
+  subject(:<%= name %>_ability) { Ability.new(<%= name %>) }
+
 <% if ability_definitions.empty? -%>
-# Define your ability tests thus;
-#
-#  describe 'on Activity' do
-#
-#    before do
-#      @activity = Factory.create(:activity)
-#    end
-#
-#    it { should be_able_to( :index,    Activity  ) }
-#    it { should be_able_to( :show,     @activity ) }
-#    it { should be_able_to( :read,     @activity ) }
-#    it { should be_able_to( :new,      @activity ) }
-#    it { should be_able_to( :create,   @activity ) }
-#    it { should be_able_to( :edit,     @activity ) }
-#    it { should be_able_to( :update,   @activity ) }
-#    it { should be_able_to( :destroy,  @activity ) }
-#
-#  end
-#  # on Activity
+#   # Define your ability tests thus;
+#   describe 'on <%= name.camelize %>' do
+#     it { is_expected.to be_able_to(:index,   <%= name.camelize %>) }
+#     it { is_expected.to be_able_to(:show,    <%= name %>) }
+#     it { is_expected.to be_able_to(:read,    <%= name %>) }
+#     it { is_expected.to be_able_to(:new,     <%= name %>) }
+#     it { is_expected.to be_able_to(:create,  <%= name %>) }
+#     it { is_expected.to be_able_to(:edit,    <%= name %>) }
+#     it { is_expected.to be_able_to(:update,  <%= name %>) }
+#     it { is_expected.to be_able_to(:destroy, <%= name %>) }
+#   end
+#   # on <%= name.camelize %>
 <% else -%>
 <% definitions do |model, definition| -%>
   <% model_name = model.camelize -%>
-  
-  describe 'on <%= model_name -%>' do
-
-    before do
-<% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-      @<%= model -%> = Factory.create(:<%= model -%>)
-<% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-      @<%= model -%> = <%= model_name -%>.make!
-<% else -%>
-      @<%= model -%> = <%= model_name -%>.create
-<% end -%>
-    end
-    
+describe 'on <%= model_name -%>' do
 <% definition.cans.each do |can| -%>
-    it { should be_able_to( <%= ":#{can},".ljust(12, ' ') + "@#{model}" -%> ) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { should_not be_able_to( <%= ":#{cannot},".ljust(12, ' ') + "@#{model}" -%> ) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
 <% end -%>
-
   end
   # on <%= model_name %>
-  <% end -%>
-  
-<% end -%>  
+<% end -%>
+<% end -%>
 end
-  

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -29,11 +29,19 @@ describe Canard::Abilities, '#<%= plural_name %>' do
 <% definitions do |model, definition| -%>
   <% model_name = model.camelize -%>
 describe 'on <%= model_name -%>' do
+<% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
+    let(:<%= model -%>) { FactoryGirl.create(:<%= model -%>) }
+<% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
+    let(:<%= model -%>) { <%= model_name -%>.make! }
+<% else -%>
+    let(:<%= model -%>) { <%= model_name -%>.create }
+<% end -%>
+
 <% definition.cans.each do |can| -%>
-    it { is_expected.to be_able_to(<%= ":#{can}, #{name}" -%>) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{name}" -%>) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
 <% end -%>
   end
   # on <%= model_name %>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:user, :<%= name %>) }
+  let(:<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
   let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
+  let(:<%= name %>) { FactoryGirl.create(:user, :<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
   let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
@@ -30,10 +30,10 @@ describe Canard::Abilities, '#<%= plural_name %>' do
   <% model_name = model.camelize -%>
 describe 'on <%= model_name -%>' do
 <% definition.cans.each do |can| -%>
-    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{name}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{name}" -%>) }
 <% end -%>
   end
   # on <%= model_name %>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'cancan/matchers'
 
-describe Canard::Abilities, 'for <%= plural_name %>' do
+describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
   let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,18 +3,19 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
+  let(:acting_<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-  let(:<%= name %>) { User.make!(:<%= name %>) }
+  let(:acting_<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
-  let(:<%= name %>) { User.create(roles: %w(<%= name -%>)) }
+  let(:acting_<%= name %>) { User.create(roles: %w(<%= name -%>)) }
 <% end -%>
-
-  subject(:<%= name %>_ability) { Ability.new(<%= name %>) }
+  subject(:<%= name %>_ability) { Ability.new(acting_<%= name %>) }
 
 <% if ability_definitions.empty? -%>
 #   # Define your ability tests thus;
 #   describe 'on <%= name.camelize %>' do
+#     let(:<%= name %>) { FactoryGirl.create(<%= name %>) }
+#
 #     it { is_expected.to be_able_to(:index,   <%= name.camelize %>) }
 #     it { is_expected.to be_able_to(:show,    <%= name %>) }
 #     it { is_expected.to be_able_to(:read,    <%= name %>) }


### PR DESCRIPTION
And adjust some of the spacing that is output, along with FactoryGirl config and rspec let vars.

Tweak documentation to point to CanCanCan

Here is what the resulting output looks like now:

### Without Definitions

```sh
rails g canard:ability person
```

```ruby
Canard::Abilities.for(:person) do
  # Define abilities for the user role here. For example:
  #
  #   if user.admin?
  #     can :manage, :all
  #   else
  #     can :read, :all
  #   end
  #
  # The first argument to `can` is the action you are giving the user permission to do.
  # If you pass :manage it will apply to every action. Other common actions here are
  # :read, :create, :update and :destroy.
  #
  # The second argument is the resource the user can perform the action on. If you pass
  # :all it will apply to every resource. Otherwise pass a Ruby class of the resource.
  #
  # The third argument is an optional hash of conditions to further filter the objects.
  # For example, here the user can only update published articles.
  #
  #   can :update, Article, published: true
  #
  # See the wiki for details: https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
end
```

```ruby
require 'rails_helper'
require 'cancan/matchers'

describe Canard::Abilities, '#people' do
  let(:person) { FactoryGirl.create(:person) }

  subject(:person_ability) { Ability.new(person) }

#   # Define your ability tests thus;
#   describe 'on Person' do
#     it { is_expected.to be_able_to(:index,   Person) }
#     it { is_expected.to be_able_to(:show,    person) }
#     it { is_expected.to be_able_to(:read,    person) }
#     it { is_expected.to be_able_to(:new,     person) }
#     it { is_expected.to be_able_to(:create,  person) }
#     it { is_expected.to be_able_to(:edit,    person) }
#     it { is_expected.to be_able_to(:update,  person) }
#     it { is_expected.to be_able_to(:destroy, person) }
#   end
#   # on Person
end
```

### With Definitions

```sh
rails g canard:ability person can:manage:person cannot:destroy:person
```

```ruby
Canard::Abilities.for(:person) do
  can [:manage], Person
  cannot [:destroy], Person
end
```

```ruby
require 'rails_helper'
require 'cancan/matchers'

describe Canard::Abilities, '#people' do
  let(:person) { FactoryGirl.create(:person) }

  subject(:person_ability) { Ability.new(person) }

  describe 'on Person' do
    it { is_expected.to be_able_to(:manage, person) }
    it { is_expected.to_not be_able_to(:destroy, person) }
  end
  # on Person
end
```