### PR TITLE
Bugfix/ar connection too soon

### DIFF
--- a/canard.gemspec
+++ b/canard.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mongoid', '~> 3.0'
 
   s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
-  s.add_runtime_dependency 'cancancan', '~> 1'
+  s.add_runtime_dependency 'cancancan', '>= 1', '< 3'
   s.add_runtime_dependency 'role_model', '~> 0'
 end

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -29,6 +29,8 @@ module Canard
 
       def active_record_table?
         respond_to?(:table_exists?) && table_exists?
+      rescue ::ActiveRecord::NoDatabaseError
+        # Hopefully we can fix this at a different level. https://github.com/rails/rails/issues/32870
       end
 
       # TODO extract has_roles_attribute? and change to has_roles_attribute? || super


### PR DESCRIPTION
I'll be testing this more, but wanted to get some early feedback. 

I know the gem isn't _super_ popular, but I'm surprised no one else has run into this yet. It'd happen for starting a new project or when running `rails db:drop` (which works without this fix) and `rails db:create` (which doesn't work without this fix) because it's trying to connect to the database before one exists while also trying to create it.