### PR TITLE
Update CanCanCan dependency to allow v2+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'bson', "~> 1.6.4"
 
   platform :ruby, :mswin, :mingw do
-    gem "sqlite3"
+    gem "sqlite3", "~> 1.3.5"
     gem "bson_ext", "~> 1.6.4"
   end
 

--- a/canard.gemspec
+++ b/canard.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mongoid', '~> 3.0'
 
   s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
-  s.add_runtime_dependency 'cancancan', '~> 1'
+  s.add_runtime_dependency 'cancancan', '>= 1'
   s.add_runtime_dependency 'role_model', '~> 0'
 end


### PR DESCRIPTION
This enables projects that use Canard to update to the latest version of CanCanCan and handles deprecation warnings for Rails 6 that are resolved in v2.x